### PR TITLE
Smart prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ The behaviour is controlled by the `smart_command` setting (default: `auto`):
 | `true`  | Always treat the prompt as a command request |
 | `false` | Never use smart command mode, always answer normally |
 
+In REPL mode, smart command keeps a rolling history of your interactions so you
+can reference them naturally ("do the same but with `-v`", "now compress that",
+etc.). Two settings control what is included:
+
+| Setting                  | Default | Description |
+|--------------------------|---------|-------------|
+| `smart_context_commands` | `true`  | Include previous prompts and commands in context |
+| `smart_context_output`   | `false` | Also capture and include command output |
+
 ## Setup
 
 1. Get API keys from your provider:
@@ -162,7 +171,9 @@ system_prompt = You are a helpful AI assistant.  # Provider-specific
 ### Smart Command
 ```ini
 [default]
-smart_command = auto  # auto, true, or false
+smart_command = auto              # auto, true, or false
+smart_context_commands = true      # include command history in context
+smart_context_output = false       # include command output in context
 ```
 
 ### Provider-Specific Settings

--- a/README.md
+++ b/README.md
@@ -32,13 +32,38 @@ lask
 
 ==== Lask REPL Mode ====
 Using provider: openai
-Enter your prompts. Type 'exit' or 'quit' to end the session.
-Press Ctrl+C to interrupt a response.
+Smart command: auto
 
 > What movie is this quote from? "that still only counts as one"
 LLM response here...
 > When was that movie released?
 ```
+
+Smart command mode also works in the REPL. When `smart_command` is `auto` or `true`, the REPL automatically detects command requests and handles them the same way — propose, confirm, execute:
+
+```
+> show disk usage for the current directory
+
+  du -sh .
+
+Press Enter to run, or any other key to abort.
+
+> explain what du does
+The `du` command estimates file space usage...
+```
+
+REPL commands:
+
+| Command   | Description |
+|-----------|-------------|
+| `!help`   | Show available REPL commands |
+| `!clear`  | Clear the screen |
+| `!history` | Show prompt history |
+| `!vi`     | Switch to Vi editing mode |
+| `!emacs`  | Switch to Emacs editing mode |
+| `exit` / `quit` | Exit the REPL |
+| `Ctrl+C`  | Interrupt a running command or response |
+| `Ctrl+D`  | Exit the REPL |
 
 Or via pipe:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Ask LLMs right from the terminal.
 - Streaming responses
 - Repl mode for interactive use, with temporary chat history
 - Pipe input support
+- **Smart command mode**: describe what you want in plain English and lask translates it into a shell command, with confirmation before execution
 
 ## Installation
 
@@ -44,6 +45,28 @@ Or via pipe:
 ```bash
 echo "What movie is this quote from? \"that still only counts as one\"" | lask
 ```
+
+### Smart Command Mode
+
+By default, lask automatically detects if your prompt is asking for a shell command. When it is, it translates your natural language into a command, shows it to you, and waits for confirmation:
+
+```bash
+$ lask show diff between current branch and main
+
+  git diff HEAD..main
+
+Press Enter to run, or any other key to abort.
+```
+
+Press **Enter** to execute, or any other key to abort. The executed command is added to your shell history, so you can press **↑** to recall and re-run or edit it.
+
+The behaviour is controlled by the `smart_command` setting (default: `auto`):
+
+| Value   | Behaviour |
+|---------|-----------|
+| `auto`  | LLM decides if the prompt is a command request or a general question |
+| `true`  | Always treat the prompt as a command request |
+| `false` | Never use smart command mode, always answer normally |
 
 ## Setup
 
@@ -109,6 +132,12 @@ system_prompt = Always answer questions concisely.
 
 [openai]
 system_prompt = You are a helpful AI assistant.  # Provider-specific
+```
+
+### Smart Command
+```ini
+[default]
+smart_command = auto  # auto, true, or false
 ```
 
 ### Provider-Specific Settings

--- a/examples/example.lask-config
+++ b/examples/example.lask-config
@@ -24,6 +24,10 @@ provider = openai
 # When true, stdout/stderr is captured and added alongside the command.
 # smart_context_output = false
 
+# Add smart commands to shell history so you can recall them with up-arrow.
+# Requires the shell hook (installed automatically when smart_command is enabled).
+# repl_commands_to_shell_history = false
+
 # OpenAI-specific configuration
 [openai]
 # Your OpenAI API key. If not specified, falls back to the default api_key

--- a/examples/example.lask-config
+++ b/examples/example.lask-config
@@ -10,6 +10,12 @@ provider = openai
 # This lets you customize how the AI responds to all your queries
 # system_prompt = Always answer questions concisely and directly.
 
+# Smart command mode: when enabled, "lask <prompt>" translates your
+# natural language prompt into a shell command and runs it after confirmation.
+# Will never run without your explicit confirmation, by pressing enter.
+# Options: true (always convert prompt to command), false (never convert prompt to command), auto (let the LLM decide if it should produce a command)
+# smart_command = auto
+
 # OpenAI-specific configuration
 [openai]
 # Your OpenAI API key. If not specified, falls back to the default api_key

--- a/examples/example.lask-config
+++ b/examples/example.lask-config
@@ -16,6 +16,14 @@ provider = openai
 # Options: true (always convert prompt to command), false (never convert prompt to command), auto (let the LLM decide if it should produce a command)
 # smart_command = auto
 
+# Include previous commands in smart command LLM context (REPL mode).
+# When true, the LLM can see your recent prompts and commands for context.
+# smart_context_commands = true
+
+# Also capture and include command output in smart command LLM context.
+# When true, stdout/stderr is captured and added alongside the command.
+# smart_context_output = false
+
 # OpenAI-specific configuration
 [openai]
 # Your OpenAI API key. If not specified, falls back to the default api_key

--- a/src/chat_history.py
+++ b/src/chat_history.py
@@ -1,0 +1,95 @@
+"""
+Chat history management for lask.
+
+Provides a consistent ChatHistory class used across REPL and one-off modes
+to manage conversation messages, system prompts, and smart command context.
+"""
+
+from typing import List, Dict
+
+from src.config import LaskConfig
+
+
+class ChatHistory:
+    """
+    Manages conversation history for consistent chat context across modes.
+
+    Encapsulates the conversation messages list and smart command history,
+    handling system prompt initialization, message tracking, and smart
+    command context assembly.
+    """
+
+    def __init__(self, config: LaskConfig, provider: str) -> None:
+        self._messages: List[Dict[str, str]] = []
+        self._command_history: List[Dict[str, str]] = []
+        self._config = config
+        self._provider = provider
+        self._init_system_prompt()
+
+    def _init_system_prompt(self) -> None:
+        """Add system prompt from config if available.
+
+        Provider-specific system prompts take precedence over the default.
+        """
+        provider_config = self._config.get_provider_config(self._provider)
+        provider_system_prompt = provider_config.system_prompt
+        default_system_prompt = self._config.system_prompt
+
+        if provider_system_prompt is not None:
+            self._messages.append({"role": "system", "content": provider_system_prompt})
+        elif default_system_prompt is not None:
+            self._messages.append({"role": "system", "content": default_system_prompt})
+
+    @property
+    def messages(self) -> List[Dict[str, str]]:
+        """The full list of conversation messages."""
+        return self._messages
+
+    @property
+    def command_history(self) -> List[Dict[str, str]]:
+        """History of smart command interactions."""
+        return self._command_history
+
+    def add_user_message(self, content: str) -> None:
+        """Append a user message to the conversation."""
+        self._messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        """Append an assistant message to the conversation."""
+        self._messages.append({"role": "assistant", "content": content})
+
+    def add_command_entry(self, entry: Dict[str, str]) -> None:
+        """Record a smart command interaction in the command history.
+
+        Args:
+            entry: Dict with keys 'prompt', 'command', and optionally 'output'.
+        """
+        self._command_history.append(entry)
+
+    def add_smart_command_context(self, entry: Dict[str, str]) -> None:
+        """Add smart command result to conversation for follow-up context.
+
+        This allows follow-up questions to reference the command and its output.
+
+        Args:
+            entry: Dict with keys 'prompt', 'command', and optionally 'output'.
+        """
+        parts: List[str] = []
+
+        if self._config.smart_context_commands == "true":
+            parts.append(f"[Ran command: {entry['command']}]")
+        else:
+            parts.append(
+                "[A command was executed but command context is disabled. "
+                "Enable with smart_context_commands=true]"
+            )
+
+        if self._config.smart_context_output == "true" and entry.get("output"):
+            parts.append(f"[Output:\n{entry['output']}\n]")
+        else:
+            parts.append(
+                "[Command output context is disabled. "
+                "Enable with smart_context_output=true]"
+            )
+
+        self._messages.append({"role": "assistant", "content": "\n".join(parts)})

--- a/src/config.py
+++ b/src/config.py
@@ -93,7 +93,10 @@ class LaskConfig:
                                 setattr(config, key, value)
                             elif key == "smart_command":
                                 setattr(config, key, value.lower().strip())
-                            elif key in ("smart_context_commands", "smart_context_output"):
+                            elif key in (
+                                "smart_context_commands",
+                                "smart_context_output",
+                            ):
                                 setattr(config, key, value.lower().strip())
                             elif key == "shell_hook":
                                 setattr(config, key, value.lower().strip())

--- a/src/config.py
+++ b/src/config.py
@@ -56,6 +56,8 @@ class LaskConfig:
     smart_context_commands: str = "true"
     # Whether to include command output in smart command LLM context
     smart_context_output: str = "false"
+    # Whether smart commands from the REPL are added to shell history
+    repl_commands_to_shell_history: str = "false"
     # Whether the user has accepted/declined the shell hook install
     # None = not yet asked, "true" = accepted, "false" = declined
     shell_hook: Optional[str] = None
@@ -96,6 +98,7 @@ class LaskConfig:
                             elif key in (
                                 "smart_context_commands",
                                 "smart_context_output",
+                                "repl_commands_to_shell_history",
                             ):
                                 setattr(config, key, value.lower().strip())
                             elif key == "shell_hook":

--- a/src/config.py
+++ b/src/config.py
@@ -52,6 +52,10 @@ class LaskConfig:
     # Smart command mode: true, false, or auto
     # auto = let the LLM decide if the prompt is a command request
     smart_command: str = "auto"
+    # Whether to include previous commands in smart command LLM context
+    smart_context_commands: str = "true"
+    # Whether to include command output in smart command LLM context
+    smart_context_output: str = "false"
     # Whether the user has accepted/declined the shell hook install
     # None = not yet asked, "true" = accepted, "false" = declined
     shell_hook: Optional[str] = None
@@ -88,6 +92,8 @@ class LaskConfig:
                             if key in ["system_prompt"]:
                                 setattr(config, key, value)
                             elif key == "smart_command":
+                                setattr(config, key, value.lower().strip())
+                            elif key in ("smart_context_commands", "smart_context_output"):
                                 setattr(config, key, value.lower().strip())
                             elif key == "shell_hook":
                                 setattr(config, key, value.lower().strip())

--- a/src/config.py
+++ b/src/config.py
@@ -49,6 +49,9 @@ class LaskConfig:
     providers: Dict[str, ProviderConfig] = field(default_factory=dict)
     # Default system prompt
     system_prompt: Optional[str] = None
+    # Smart command mode: true, false, or auto
+    # auto = let the LLM decide if the prompt is a command request
+    smart_command: str = "auto"
 
     # Class constants
     CONFIG_PATH: ClassVar[Path] = Path.home() / ".lask-config"
@@ -81,6 +84,8 @@ class LaskConfig:
                             # Handle type conversion for specific fields
                             if key in ["system_prompt"]:
                                 setattr(config, key, value)
+                            elif key == "smart_command":
+                                setattr(config, key, value.lower().strip())
                             else:
                                 setattr(config, key, value)
 

--- a/src/config.py
+++ b/src/config.py
@@ -52,6 +52,9 @@ class LaskConfig:
     # Smart command mode: true, false, or auto
     # auto = let the LLM decide if the prompt is a command request
     smart_command: str = "auto"
+    # Whether the user has accepted/declined the shell hook install
+    # None = not yet asked, "true" = accepted, "false" = declined
+    shell_hook: Optional[str] = None
 
     # Class constants
     CONFIG_PATH: ClassVar[Path] = Path.home() / ".lask-config"
@@ -85,6 +88,8 @@ class LaskConfig:
                             if key in ["system_prompt"]:
                                 setattr(config, key, value)
                             elif key == "smart_command":
+                                setattr(config, key, value.lower().strip())
+                            elif key == "shell_hook":
                                 setattr(config, key, value.lower().strip())
                             else:
                                 setattr(config, key, value)
@@ -150,6 +155,24 @@ class LaskConfig:
             Any: The configuration value
         """
         return getattr(self, key, default) if hasattr(self, key) else default
+
+    def save_setting(self, section: str, key: str, value: str) -> None:
+        """
+        Save a single setting to the config file, preserving existing content.
+
+        Args:
+            section (str): The config section (e.g. 'default')
+            key (str): The setting key
+            value (str): The setting value
+        """
+        parser = configparser.ConfigParser()
+        if self.CONFIG_PATH.exists():
+            parser.read(self.CONFIG_PATH)
+        if section not in parser:
+            parser[section] = {}
+        parser[section][key] = value
+        with open(self.CONFIG_PATH, "w") as f:
+            parser.write(f)
 
     def __getitem__(self, key: str) -> Any:
         """Allow dictionary-like access to attributes."""

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ Features:
 
 import sys
 import os
+import platform
 import subprocess
 import tty
 import termios
@@ -390,9 +391,16 @@ def repl_mode(config: LaskConfig) -> None:
     # Initialize conversation history
     conversation = setup_conversation(config, provider)
 
+    # Check smart command setting for REPL routing
+    smart = config.smart_command
+    if smart in ("true", "auto"):
+        ensure_shell_hook(config)
+
     # Display welcome message
     print("\n==== Lask REPL Mode ====")
     print(f"Using provider: {provider}")
+    if smart in ("true", "auto"):
+        print(f"Smart command: {smart}")
 
     # Show help information
     display_repl_help()
@@ -431,7 +439,22 @@ def repl_mode(config: LaskConfig) -> None:
             if not user_input.strip():
                 continue
 
-            # Add user message to conversation
+            # Route through smart command if applicable
+            use_smart = False
+            if smart == "true":
+                use_smart = True
+            elif smart == "auto":
+                use_smart = classify_prompt(config, user_input)
+
+            if use_smart:
+                # Smart command: translate to shell command, don't add to conversation
+                try:
+                    run_smart_command(config, user_input, is_repl=True)
+                except Exception as e:
+                    print(f"\nError: {str(e)}")
+                continue
+
+            # Regular prompt: add to conversation and get response
             conversation.append({"role": "user", "content": user_input})
 
             try:
@@ -511,31 +534,32 @@ def write_last_command(command: str) -> None:
         pass
 
 
-def process_smart_command(config: LaskConfig, prompt: str) -> None:
+def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) -> bool:
     """
-    Process a prompt in smart command mode: send the prompt to the LLM,
-    get back a shell command, and execute it after user confirmation.
+    Core smart command logic: send the prompt to the LLM, get back a shell
+    command, display it, and execute after user confirmation.
+
+    This is the reusable core used by both one-off and REPL modes.
 
     Args:
         config (LaskConfig): Configuration object
         prompt (str): The user's natural language description of a command
-    """
-    # Make sure the shell hook is installed so up-arrow recall works
-    ensure_shell_hook(config)
 
+    Returns:
+        bool: True if the command ran successfully, False on error or abort
+    """
     provider: str = config.get("provider", "openai").lower()
 
     if provider not in LaskConfig.SUPPORTED_PROVIDERS:
         print(
             f"Error: Unsupported provider '{provider}'. Supported providers are: {', '.join(LaskConfig.SUPPORTED_PROVIDERS)}"
         )
-        sys.exit(1)
+        return False
 
     # Build a conversation with a system prompt that instructs the LLM
     # to only return a shell command
-    import platform
-    os_info = platform.system()       # e.g. "Darwin", "Linux", "Windows"
-    os_version = platform.release()   # e.g. "23.4.0"
+    os_info = platform.system()  # e.g. "Darwin", "Linux", "Windows"
+    os_version = platform.release()  # e.g. "23.4.0"
     shell = os.environ.get("SHELL", "unknown")
 
     smart_system_prompt = (
@@ -573,7 +597,7 @@ def process_smart_command(config: LaskConfig, prompt: str) -> None:
 
         if not command:
             print("Error: LLM returned an empty command.")
-            sys.exit(1)
+            return False
 
         # Display the command and ask for confirmation
         print(f"\n  \033[1;36m{command}\033[0m\n")
@@ -595,15 +619,37 @@ def process_smart_command(config: LaskConfig, prompt: str) -> None:
         # Check if the key was Enter (\r or \n)
         if ch in ("\r", "\n"):
             print()  # newline after the keypress
-            subprocess.run(command, shell=True)
+            try:
+                subprocess.run(command, shell=True)
+            except KeyboardInterrupt:
+                if is_repl:
+                    print("\n\nCommand interrupted.")
             # Save the command so the shell hook can inject it
             # into live history (press up-arrow to recall)
             write_last_command(command)
         else:
             print("\nAborted.")
 
+        return True
+
     except Exception as e:
         print(f"Error: {str(e)}")
+        return False
+
+
+def process_smart_command(config: LaskConfig, prompt: str) -> None:
+    """
+    Process a prompt in smart command mode (one-off, non-REPL).
+    Wraps run_smart_command with shell hook setup and exit handling.
+
+    Args:
+        config (LaskConfig): Configuration object
+        prompt (str): The user's natural language description of a command
+    """
+    # Make sure the shell hook is installed so up-arrow recall works
+    ensure_shell_hook(config)
+
+    if not run_smart_command(config, prompt):
         sys.exit(1)
 
 
@@ -670,9 +716,11 @@ def ensure_shell_hook(config: LaskConfig) -> None:
                     return
 
         # Not installed yet and user hasn't been asked — prompt them
-        print("\n\033[33mlask can add a small shell hook to your "
-              f"{os.path.basename(rc_file)} so that commands from smart mode "
-              "appear in your shell history (press \u2191 to recall).\033[0m")
+        print(
+            "\n\033[33mlask can add a small shell hook to your "
+            f"{os.path.basename(rc_file)} so that commands from smart mode "
+            "appear in your shell history (press \u2191 to recall).\033[0m"
+        )
         answer = input("Install shell hook? [Y/n] ").strip().lower()
 
         if answer in ("", "y", "yes"):
@@ -680,8 +728,10 @@ def ensure_shell_hook(config: LaskConfig) -> None:
                 f.write(hook)
             config.shell_hook = "true"
             config.save_setting("default", "shell_hook", "true")
-            print(f"\033[32mInstalled. Run \033[1msource {rc_file}\033[0;32m "
-                  f"or open a new terminal to activate.\033[0m\n")
+            print(
+                f"\033[32mInstalled. Run \033[1msource {rc_file}\033[0;32m "
+                f"or open a new terminal to activate.\033[0m\n"
+            )
         else:
             config.shell_hook = "false"
             config.save_setting("default", "shell_hook", "false")

--- a/src/main.py
+++ b/src/main.py
@@ -20,8 +20,6 @@ import sys
 import os
 import platform
 import subprocess
-import tty
-import termios
 from typing import Union, Iterator, List, Dict
 import readline  # For better input handling in REPL mode
 import atexit
@@ -650,13 +648,20 @@ def run_smart_command(
         )
 
         # Read a single keypress without requiring Enter
-        fd = sys.stdin.fileno()
-        old_settings = termios.tcgetattr(fd)
-        try:
-            tty.setraw(fd)
-            ch = sys.stdin.read(1)
-        finally:
-            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        if os.name == "posix":
+            import tty
+            import termios
+
+            fd = sys.stdin.fileno()
+            old_settings = termios.tcgetattr(fd)
+            try:
+                tty.setraw(fd)
+                ch = sys.stdin.read(1)
+            finally:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        else:
+            # Windows (or other non-POSIX): fall back to a simple prompt
+            ch = input() or "\n"
 
         # Check if the key was Enter (\r or \n)
         if ch in ("\r", "\n"):

--- a/src/main.py
+++ b/src/main.py
@@ -393,6 +393,7 @@ def repl_mode(config: LaskConfig) -> None:
 
     # Check smart command setting for REPL routing
     smart = config.smart_command
+    command_history: List[Dict[str, str]] = []
     if smart in ("true", "auto"):
         ensure_shell_hook(config)
 
@@ -449,7 +450,37 @@ def repl_mode(config: LaskConfig) -> None:
             if use_smart:
                 # Smart command: translate to shell command, don't add to conversation
                 try:
-                    run_smart_command(config, user_input, is_repl=True)
+                    hist = (
+                        command_history
+                        if config.smart_context_commands == "true"
+                        else []
+                    )
+                    result = run_smart_command(
+                        config, user_input, is_repl=True, command_history=hist
+                    )
+                    if result is not None:
+                        command_history.append(result)
+                        # Add to conversation so follow-up questions can
+                        # reference the command and its output
+                        parts = []
+                        if config.smart_context_commands == "true":
+                            parts.append(f"[Ran command: {result['command']}]")
+                        else:
+                            parts.append(
+                                "[A command was executed but command context is disabled. Enable with smart_context_commands=true]"
+                            )
+                        if (
+                            config.smart_context_output == "true"
+                            and result.get("output")
+                        ):
+                            parts.append(f"[Output:\n{result['output']}\n]")
+                        else:
+                            parts.append(
+                                "[Command output context is disabled. Enable with smart_context_output=true]"
+                            )
+                        conversation.append(
+                            {"role": "assistant", "content": "\n".join(parts)}
+                        )
                 except Exception as e:
                     print(f"\nError: {str(e)}")
                 continue
@@ -534,7 +565,12 @@ def write_last_command(command: str) -> None:
         pass
 
 
-def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) -> bool:
+def run_smart_command(
+    config: LaskConfig,
+    prompt: str,
+    is_repl: bool = False,
+    command_history: List[Dict[str, str]] | None = None,
+) -> Dict[str, str] | None:
     """
     Core smart command logic: send the prompt to the LLM, get back a shell
     command, display it, and execute after user confirmation.
@@ -544,9 +580,13 @@ def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) ->
     Args:
         config (LaskConfig): Configuration object
         prompt (str): The user's natural language description of a command
+        is_repl (bool): Whether running inside the REPL (affects interrupt msg)
+        command_history (list | None): Previous interactions, each entry is
+            {"prompt": "...", "command": "...", "output": "..."}
 
     Returns:
-        bool: True if the command ran successfully, False on error or abort
+        dict | None: {"prompt": ..., "command": ..., "output": ...} for the
+                     executed command, or None on error.
     """
     provider: str = config.get("provider", "openai").lower()
 
@@ -554,7 +594,7 @@ def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) ->
         print(
             f"Error: Unsupported provider '{provider}'. Supported providers are: {', '.join(LaskConfig.SUPPORTED_PROVIDERS)}"
         )
-        return False
+        return None
 
     # Build a conversation with a system prompt that instructs the LLM
     # to only return a shell command
@@ -571,6 +611,19 @@ def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) ->
         f"Platform: {os_info} {os_version}, Shell: {shell}. "
         "Use commands and flags compatible with this platform."
     )
+    if command_history:
+        history_lines = []
+        for entry in command_history:
+            history_lines.append(f"User: {entry['prompt']}")
+            history_lines.append(f"$ {entry['command']}")
+            if entry.get("output"):
+                history_lines.append(entry["output"])
+        history_text = "\n".join(history_lines)
+        smart_system_prompt += (
+            f"\n\nRecent smart command history:\n{history_text}\n"
+            "If the user references 'it', 'that', 'this', 'the same', 'instead', etc., "
+            "they are likely referring to a recent command and want a variation of it."
+        )
     conversation: List[Dict[str, str]] = [
         {"role": "system", "content": smart_system_prompt},
         {"role": "user", "content": prompt},
@@ -597,7 +650,7 @@ def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) ->
 
         if not command:
             print("Error: LLM returned an empty command.")
-            return False
+            return None
 
         # Display the command and ask for confirmation
         print(f"\n  \033[1;36m{command}\033[0m\n")
@@ -619,8 +672,26 @@ def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) ->
         # Check if the key was Enter (\r or \n)
         if ch in ("\r", "\n"):
             print()  # newline after the keypress
+            entry: Dict[str, str] = {"prompt": prompt, "command": command}
+            capture_output = config.smart_context_output == "true"
             try:
-                subprocess.run(command, shell=True)
+                if capture_output:
+                    # Stream output live to the terminal while collecting it
+                    proc = subprocess.Popen(
+                        command,
+                        shell=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                    )
+                    chunks: list[str] = []
+                    for line in proc.stdout:  # type: ignore[union-attr]
+                        print(line, end="", flush=True)
+                        chunks.append(line)
+                    proc.wait()
+                    entry["output"] = "".join(chunks).strip()
+                else:
+                    subprocess.run(command, shell=True)
             except KeyboardInterrupt:
                 if is_repl:
                     print("\n\nCommand interrupted.")
@@ -629,12 +700,13 @@ def run_smart_command(config: LaskConfig, prompt: str, is_repl: bool = False) ->
             write_last_command(command)
         else:
             print("\nAborted.")
+            entry = {"prompt": prompt, "command": command}
 
-        return True
+        return entry
 
     except Exception as e:
         print(f"Error: {str(e)}")
-        return False
+        return None
 
 
 def process_smart_command(config: LaskConfig, prompt: str) -> None:
@@ -649,7 +721,7 @@ def process_smart_command(config: LaskConfig, prompt: str) -> None:
     # Make sure the shell hook is installed so up-arrow recall works
     ensure_shell_hook(config)
 
-    if not run_smart_command(config, prompt):
+    if run_smart_command(config, prompt) is None:
         sys.exit(1)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -499,11 +499,14 @@ def write_last_command(command: str) -> None:
     Write the command to ~/.lask_last_command so the shell hook
     (installed via `lask --shell-init`) can inject it into the
     live shell history on the next prompt.
+    Newlines are escaped to prevent the shell from splitting the command.
     """
     try:
         last_cmd_path = os.path.expanduser("~/.lask_last_command")
+        # Escape backslashes first, then newlines
+        escaped = command.replace("\\", "\\\\").replace("\n", "\\n")
         with open(last_cmd_path, "w") as f:
-            f.write(command)
+            f.write(escaped)
     except Exception:
         pass
 
@@ -518,7 +521,7 @@ def process_smart_command(config: LaskConfig, prompt: str) -> None:
         prompt (str): The user's natural language description of a command
     """
     # Make sure the shell hook is installed so up-arrow recall works
-    ensure_shell_hook()
+    ensure_shell_hook(config)
 
     provider: str = config.get("provider", "openai").lower()
 
@@ -530,12 +533,19 @@ def process_smart_command(config: LaskConfig, prompt: str) -> None:
 
     # Build a conversation with a system prompt that instructs the LLM
     # to only return a shell command
+    import platform
+    os_info = platform.system()       # e.g. "Darwin", "Linux", "Windows"
+    os_version = platform.release()   # e.g. "23.4.0"
+    shell = os.environ.get("SHELL", "unknown")
+
     smart_system_prompt = (
         "You are a command-line assistant. The user will describe what they want to do "
         "and you must respond with ONLY the exact shell command to accomplish it. "
         "Do not include any explanation, markdown formatting, code fences, or extra text. "
         "Respond with a single command (use && or | to chain if needed). "
-        "If the request is ambiguous, make a reasonable assumption and provide the most common command."
+        "If the request is ambiguous, make a reasonable assumption and provide the most common command.\n"
+        f"Platform: {os_info} {os_version}, Shell: {shell}. "
+        "Use commands and flags compatible with this platform."
     )
     conversation: List[Dict[str, str]] = [
         {"role": "system", "content": smart_system_prompt},
@@ -598,12 +608,14 @@ def process_smart_command(config: LaskConfig, prompt: str) -> None:
 
 
 # Shell hook snippet for zsh
-_ZSH_HOOK = """\n# lask: inject smart-command into live shell history
+_ZSH_HOOK = """
+# lask: inject smart-command into live shell history
 _lask_precmd() {
     local f=~/.lask_last_command
     if [[ -f "$f" ]]; then
         local cmd="$(<"$f")"
         rm -f "$f"
+        cmd="${cmd//\\\\n/$'\\n'}"
         print -s -- "$cmd"
     fi
 }
@@ -617,6 +629,7 @@ _BASH_HOOK = (
     '    if [[ -f "$f" ]]; then\n'
     '        local cmd="$(cat "$f")"\n'
     '        rm -f "$f"\n'
+    "        cmd=\"${cmd//\\\\n/$'\\n'}\"\n"
     '        history -s "$cmd"\n'
     "    fi\n"
     "}\n"
@@ -624,11 +637,17 @@ _BASH_HOOK = (
 )
 
 
-def ensure_shell_hook() -> None:
+def ensure_shell_hook(config: LaskConfig) -> None:
     """
     Ensure the lask shell hook is installed in the user's shell rc file.
-    If missing, append it and notify the user once.
+    - If already installed in the rc file, do nothing.
+    - If the user previously declined (shell_hook = false in config), do nothing.
+    - Otherwise, prompt the user to install it.
     """
+    # User already declined
+    if config.shell_hook == "false":
+        return
+
     shell = os.environ.get("SHELL", "")
 
     if "zsh" in shell:
@@ -644,17 +663,30 @@ def ensure_shell_hook() -> None:
             with open(rc_file, "r") as f:
                 contents = f.read()
                 if "_lask_precmd" in contents or "_lask_prompt_cmd" in contents:
-                    return  # Already installed
+                    # Already installed, save so we don't check the file again
+                    if config.shell_hook != "true":
+                        config.shell_hook = "true"
+                        config.save_setting("default", "shell_hook", "true")
+                    return
 
-        # Append the hook
-        with open(rc_file, "a") as f:
-            f.write(hook)
+        # Not installed yet and user hasn't been asked — prompt them
+        print("\n\033[33mlask can add a small shell hook to your "
+              f"{os.path.basename(rc_file)} so that commands from smart mode "
+              "appear in your shell history (press \u2191 to recall).\033[0m")
+        answer = input("Install shell hook? [Y/n] ").strip().lower()
 
-        print(
-            f"\033[33mInstalled lask shell hook in {rc_file}.\n"
-            f"Run \033[1msource {rc_file}\033[0;33m or open a new terminal "
-            f"for up-arrow history to work.\033[0m\n"
-        )
+        if answer in ("", "y", "yes"):
+            with open(rc_file, "a") as f:
+                f.write(hook)
+            config.shell_hook = "true"
+            config.save_setting("default", "shell_hook", "true")
+            print(f"\033[32mInstalled. Run \033[1msource {rc_file}\033[0;32m "
+                  f"or open a new terminal to activate.\033[0m\n")
+        else:
+            config.shell_hook = "false"
+            config.save_setting("default", "shell_hook", "false")
+            print("Skipped. You won't be asked again.\n")
+
     except Exception:
         pass
 

--- a/src/main.py
+++ b/src/main.py
@@ -285,6 +285,7 @@ def handle_repl_command(cmd, history):
     """
     if cmd == "help":
         print("\nREPL Commands:")
+        print("  ! <cmd>   - Run a shell command directly")
         print("  !help     - Show this help")
         print("  !clear    - Clear the screen")
         print("  !history  - Show command history")
@@ -335,6 +336,7 @@ def display_repl_help():
 
     # Show common commands
     print("\nCommon commands:")
+    print("- Type '! <cmd>' to run a shell command directly")
     print("- Type '!help' for REPL help")
     print("- Type '!clear' to clear the screen")
     print("- Type '!history' to show command history")
@@ -368,7 +370,7 @@ def repl_mode(config: LaskConfig) -> None:
 
     # Check smart command setting for REPL routing
     smart = config.smart_command
-    if smart in ("true", "auto"):
+    if smart in ("true", "auto") and config.repl_commands_to_shell_history == "true":
         ensure_shell_hook(config)
 
     # Display welcome message
@@ -406,7 +408,38 @@ def repl_mode(config: LaskConfig) -> None:
 
             # Check for special REPL commands
             if user_input.startswith("!"):
-                cmd = user_input[1:].strip().lower()
+                rest = user_input[1:]
+                # "! <command>" runs a shell command directly (treated like a smart command)
+                if rest.startswith(" ") and rest.strip():
+                    command = rest.strip()
+                    entry: Dict[str, str] = {"prompt": user_input, "command": command}
+                    capture_output = config.smart_context_output == "true"
+                    chunks: list[str] = []
+                    try:
+                        if capture_output:
+                            proc = subprocess.Popen(
+                                command,
+                                shell=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                text=True,
+                            )
+                            for line in proc.stdout:  # type: ignore[union-attr]
+                                print(line, end="", flush=True)
+                                chunks.append(line)
+                            proc.wait()
+                        else:
+                            subprocess.run(command, shell=True)
+                    except KeyboardInterrupt:
+                        print("\n\nCommand interrupted.")
+                    if capture_output and chunks:
+                        entry["output"] = "".join(chunks).strip()
+                    if config.repl_commands_to_shell_history == "true":
+                        write_last_command(command)
+                    history.add_command_entry(entry)
+                    history.add_smart_command_context(entry)
+                    continue
+                cmd = rest.strip().lower()
                 if handle_repl_command(cmd, history):
                     continue
 
@@ -656,7 +689,8 @@ def run_smart_command(
                 entry["output"] = "".join(chunks).strip()
             # Save the command so the shell hook can inject it
             # into live history (press up-arrow to recall)
-            write_last_command(command)
+            if not is_repl or config.repl_commands_to_shell_history == "true":
+                write_last_command(command)
         else:
             print("\nAborted.")
             entry = {"prompt": prompt, "command": command}

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ import atexit
 
 import configparser
 from src.config import LaskConfig
+from src.chat_history import ChatHistory
 from src.providers import call_provider_api
 
 
@@ -240,32 +241,6 @@ def setup_readline():
         pass
 
 
-def setup_conversation(config: LaskConfig, provider: str) -> List[Dict[str, str]]:
-    """
-    Set up the initial conversation with system prompt if available.
-
-    Args:
-        config (LaskConfig): Configuration object
-        provider (str): The provider name
-
-    Returns:
-        List[Dict[str, str]]: Initial conversation history
-    """
-    conversation: List[Dict[str, str]] = []
-
-    # Add system message if specified in config
-    provider_config = config.get_provider_config(provider)
-    provider_system_prompt = provider_config.system_prompt
-    default_system_prompt = config.system_prompt
-
-    if provider_system_prompt is not None:
-        conversation.append({"role": "system", "content": provider_system_prompt})
-    elif default_system_prompt is not None:
-        conversation.append({"role": "system", "content": default_system_prompt})
-
-    return conversation
-
-
 def process_response(result: Union[str, Iterator[str]]) -> str:
     """
     Process the response from the provider.
@@ -297,13 +272,13 @@ def process_response(result: Union[str, Iterator[str]]) -> str:
     return full_response
 
 
-def handle_repl_command(cmd, conversation):
+def handle_repl_command(cmd, history):
     """
     Handle special REPL commands starting with !
 
     Args:
         cmd (str): The command without the ! prefix
-        conversation (List): The current conversation history
+        history (ChatHistory): The current chat history
 
     Returns:
         bool: True if the command was handled, False otherwise
@@ -388,12 +363,11 @@ def repl_mode(config: LaskConfig) -> None:
     # Configure readline for better line editing
     setup_readline()
 
-    # Initialize conversation history
-    conversation = setup_conversation(config, provider)
+    # Initialize chat history (handles system prompt automatically)
+    history = ChatHistory(config, provider)
 
     # Check smart command setting for REPL routing
     smart = config.smart_command
-    command_history: List[Dict[str, str]] = []
     if smart in ("true", "auto"):
         ensure_shell_hook(config)
 
@@ -433,7 +407,7 @@ def repl_mode(config: LaskConfig) -> None:
             # Check for special REPL commands
             if user_input.startswith("!"):
                 cmd = user_input[1:].strip().lower()
-                if handle_repl_command(cmd, conversation):
+                if handle_repl_command(cmd, history):
                     continue
 
             # Skip empty inputs
@@ -450,53 +424,35 @@ def repl_mode(config: LaskConfig) -> None:
             if use_smart:
                 # Smart command: translate to shell command, don't add to conversation
                 try:
-                    hist = (
-                        command_history
+                    cmd_hist = (
+                        history.command_history
                         if config.smart_context_commands == "true"
                         else []
                     )
                     result = run_smart_command(
-                        config, user_input, is_repl=True, command_history=hist
+                        config, user_input, is_repl=True, command_history=cmd_hist
                     )
                     if result is not None:
-                        command_history.append(result)
-                        # Add to conversation so follow-up questions can
-                        # reference the command and its output
-                        parts = []
-                        if config.smart_context_commands == "true":
-                            parts.append(f"[Ran command: {result['command']}]")
-                        else:
-                            parts.append(
-                                "[A command was executed but command context is disabled. Enable with smart_context_commands=true]"
-                            )
-                        if (
-                            config.smart_context_output == "true"
-                            and result.get("output")
-                        ):
-                            parts.append(f"[Output:\n{result['output']}\n]")
-                        else:
-                            parts.append(
-                                "[Command output context is disabled. Enable with smart_context_output=true]"
-                            )
-                        conversation.append(
-                            {"role": "assistant", "content": "\n".join(parts)}
-                        )
+                        history.add_command_entry(result)
+                        history.add_smart_command_context(result)
                 except Exception as e:
                     print(f"\nError: {str(e)}")
                 continue
 
             # Regular prompt: add to conversation and get response
-            conversation.append({"role": "user", "content": user_input})
+            history.add_user_message(user_input)
 
             try:
                 # Call the provider API with the full conversation history
-                result = call_provider_api(provider, config, user_input, conversation)
+                result = call_provider_api(
+                    provider, config, user_input, history.messages
+                )
 
                 # Process the response and get the full text
                 full_response = process_response(result)
 
                 # Add assistant's response to conversation history
-                conversation.append({"role": "assistant", "content": full_response})
+                history.add_assistant_message(full_response)
 
             except Exception as e:
                 print(f"\nError: {str(e)}")
@@ -674,6 +630,7 @@ def run_smart_command(
             print()  # newline after the keypress
             entry: Dict[str, str] = {"prompt": prompt, "command": command}
             capture_output = config.smart_context_output == "true"
+            chunks: list[str] = []
             try:
                 if capture_output:
                     # Stream output live to the terminal while collecting it
@@ -684,17 +641,19 @@ def run_smart_command(
                         stderr=subprocess.STDOUT,
                         text=True,
                     )
-                    chunks: list[str] = []
                     for line in proc.stdout:  # type: ignore[union-attr]
                         print(line, end="", flush=True)
                         chunks.append(line)
                     proc.wait()
-                    entry["output"] = "".join(chunks).strip()
                 else:
                     subprocess.run(command, shell=True)
             except KeyboardInterrupt:
                 if is_repl:
                     print("\n\nCommand interrupted.")
+            # Always save whatever output was captured (including partial
+            # output when the command was interrupted with Ctrl+C)
+            if capture_output and chunks:
+                entry["output"] = "".join(chunks).strip()
             # Save the command so the shell hook can inject it
             # into live history (press up-arrow to recall)
             write_last_command(command)
@@ -911,6 +870,8 @@ def process_one_off_prompt(config: LaskConfig, prompt: str) -> None:
     """
     Process a one-off prompt without maintaining conversation context.
 
+    Uses ChatHistory for consistent system prompt handling across modes.
+
     Args:
         config (LaskConfig): Configuration object
         prompt (str): The user prompt
@@ -925,21 +886,18 @@ def process_one_off_prompt(config: LaskConfig, prompt: str) -> None:
         )
         sys.exit(1)
 
+    # Build conversation with system prompt via ChatHistory
+    history = ChatHistory(config, provider)
+    history.add_user_message(prompt)
+
     try:
         # Call the appropriate API based on the provider using the provider modules
-        result: Union[str, Iterator[str]] = call_provider_api(provider, config, prompt)
+        result: Union[str, Iterator[str]] = call_provider_api(
+            provider, config, prompt, history.messages
+        )
 
-        # Handle streaming vs non-streaming responses
-        if isinstance(result, str):
-            # Non-streaming response - full text is returned at once
-            print(result)
-        else:
-            # Streaming response - print chunks as they arrive in real-time
-            # This provides immediate feedback as the LLM generates content
-            for chunk in result:
-                # Print without buffering and without newline to create a continuous output
-                print(chunk, end="", flush=True)
-            print()  # Add a newline at the end of the complete response
+        # Process the response (handles both streaming and non-streaming)
+        process_response(result)
 
     except ImportError as e:
         print(f"Error: {str(e)}")

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,9 @@ Features:
 
 import sys
 import os
+import subprocess
+import tty
+import termios
 from typing import Union, Iterator, List, Dict
 import readline  # For better input handling in REPL mode
 import atexit
@@ -449,6 +452,248 @@ def repl_mode(config: LaskConfig) -> None:
         print("\nExiting...")
 
 
+def classify_prompt(config: LaskConfig, prompt: str) -> bool:
+    """
+    Ask the LLM whether the user's prompt is a request for a shell command.
+
+    Args:
+        config (LaskConfig): Configuration object
+        prompt (str): The user's prompt
+
+    Returns:
+        bool: True if the prompt looks like a shell command request
+    """
+    provider: str = config.get("provider", "openai").lower()
+
+    classification_system_prompt = (
+        "You are a classifier. The user will give you a prompt. "
+        "Determine if the user is asking for a shell/terminal command to be executed, "
+        "or if they are asking a general knowledge question. "
+        "Respond with ONLY the single word: command or question. "
+        "Nothing else."
+    )
+    conversation: List[Dict[str, str]] = [
+        {"role": "system", "content": classification_system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+
+    try:
+        result = call_provider_api(provider, config, prompt, conversation)
+
+        answer = ""
+        if isinstance(result, str):
+            answer = result.strip().lower()
+        else:
+            for chunk in result:
+                answer += chunk
+            answer = answer.strip().lower()
+
+        return "command" in answer
+    except Exception:
+        # If classification fails, fall back to normal prompt
+        return False
+
+
+def write_last_command(command: str) -> None:
+    """
+    Write the command to ~/.lask_last_command so the shell hook
+    (installed via `lask --shell-init`) can inject it into the
+    live shell history on the next prompt.
+    """
+    try:
+        last_cmd_path = os.path.expanduser("~/.lask_last_command")
+        with open(last_cmd_path, "w") as f:
+            f.write(command)
+    except Exception:
+        pass
+
+
+def process_smart_command(config: LaskConfig, prompt: str) -> None:
+    """
+    Process a prompt in smart command mode: send the prompt to the LLM,
+    get back a shell command, and execute it after user confirmation.
+
+    Args:
+        config (LaskConfig): Configuration object
+        prompt (str): The user's natural language description of a command
+    """
+    # Make sure the shell hook is installed so up-arrow recall works
+    ensure_shell_hook()
+
+    provider: str = config.get("provider", "openai").lower()
+
+    if provider not in LaskConfig.SUPPORTED_PROVIDERS:
+        print(
+            f"Error: Unsupported provider '{provider}'. Supported providers are: {', '.join(LaskConfig.SUPPORTED_PROVIDERS)}"
+        )
+        sys.exit(1)
+
+    # Build a conversation with a system prompt that instructs the LLM
+    # to only return a shell command
+    smart_system_prompt = (
+        "You are a command-line assistant. The user will describe what they want to do "
+        "and you must respond with ONLY the exact shell command to accomplish it. "
+        "Do not include any explanation, markdown formatting, code fences, or extra text. "
+        "Respond with a single command (use && or | to chain if needed). "
+        "If the request is ambiguous, make a reasonable assumption and provide the most common command."
+    )
+    conversation: List[Dict[str, str]] = [
+        {"role": "system", "content": smart_system_prompt},
+        {"role": "user", "content": prompt},
+    ]
+
+    try:
+        # Call the provider, collecting the full response
+        result = call_provider_api(provider, config, prompt, conversation)
+
+        command = ""
+        if isinstance(result, str):
+            command = result.strip()
+        else:
+            for chunk in result:
+                command += chunk
+            command = command.strip()
+
+        # Remove markdown code fences if the LLM wrapped the command
+        if command.startswith("```") and command.endswith("```"):
+            lines = command.split("\n")
+            command = "\n".join(lines[1:-1]).strip()
+        elif command.startswith("`") and command.endswith("`"):
+            command = command.strip("`").strip()
+
+        if not command:
+            print("Error: LLM returned an empty command.")
+            sys.exit(1)
+
+        # Display the command and ask for confirmation
+        print(f"\n  \033[1;36m{command}\033[0m\n")
+        print(
+            "Press \033[1mEnter\033[0m to run, or \033[1many other key\033[0m to abort.",
+            end=" ",
+            flush=True,
+        )
+
+        # Read a single keypress without requiring Enter
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+        # Check if the key was Enter (\r or \n)
+        if ch in ("\r", "\n"):
+            print()  # newline after the keypress
+            subprocess.run(command, shell=True)
+            # Save the command so the shell hook can inject it
+            # into live history (press up-arrow to recall)
+            write_last_command(command)
+        else:
+            print("\nAborted.")
+
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)
+
+
+# Shell hook snippet for zsh
+_ZSH_HOOK = """\n# lask: inject smart-command into live shell history
+_lask_precmd() {
+    local f=~/.lask_last_command
+    if [[ -f "$f" ]]; then
+        local cmd="$(<"$f")"
+        rm -f "$f"
+        print -s -- "$cmd"
+    fi
+}
+precmd_functions+=(_lask_precmd)"""
+
+# Shell hook snippet for bash
+_BASH_HOOK = (
+    "\n# lask: inject smart-command into live shell history\n"
+    "_lask_prompt_cmd() {\n"
+    "    local f=~/.lask_last_command\n"
+    '    if [[ -f "$f" ]]; then\n'
+    '        local cmd="$(cat "$f")"\n'
+    '        rm -f "$f"\n'
+    '        history -s "$cmd"\n'
+    "    fi\n"
+    "}\n"
+    'PROMPT_COMMAND="_lask_prompt_cmd;${PROMPT_COMMAND}"\n'
+)
+
+
+def ensure_shell_hook() -> None:
+    """
+    Ensure the lask shell hook is installed in the user's shell rc file.
+    If missing, append it and notify the user once.
+    """
+    shell = os.environ.get("SHELL", "")
+
+    if "zsh" in shell:
+        rc_file = os.path.expanduser("~/.zshrc")
+        hook = _ZSH_HOOK
+    else:
+        rc_file = os.path.expanduser("~/.bashrc")
+        hook = _BASH_HOOK
+
+    try:
+        # Check if hook is already present
+        if os.path.exists(rc_file):
+            with open(rc_file, "r") as f:
+                contents = f.read()
+                if "_lask_precmd" in contents or "_lask_prompt_cmd" in contents:
+                    return  # Already installed
+
+        # Append the hook
+        with open(rc_file, "a") as f:
+            f.write(hook)
+
+        print(
+            f"\033[33mInstalled lask shell hook in {rc_file}.\n"
+            f"Run \033[1msource {rc_file}\033[0;33m or open a new terminal "
+            f"for up-arrow history to work.\033[0m\n"
+        )
+    except Exception:
+        pass
+
+
+def print_shell_init() -> None:
+    """
+    Print the shell hook that should be added to ~/.zshrc or ~/.bashrc.
+    This hook injects the last smart-command into the live shell history
+    so it can be recalled immediately with the up arrow.
+    """
+    shell = os.environ.get("SHELL", "")
+
+    if "zsh" in shell:
+        print("""# lask: inject smart-command into live shell history
+_lask_precmd() {
+    local f=~/.lask_last_command
+    if [[ -f "$f" ]]; then
+        local cmd="$(cat "$f")"
+        rm -f "$f"
+        print -s "$cmd"
+    fi
+}
+precmd_functions+=(_lask_precmd)""")
+    else:
+        init_code = (
+            "# lask: inject smart-command into live shell history\n"
+            "_lask_prompt_cmd() {\n"
+            "    local f=~/.lask_last_command\n"
+            '    if [[ -f "$f" ]]; then\n'
+            '        local cmd="$(cat "$f")"\n'
+            '        rm -f "$f"\n'
+            '        history -s "$cmd"\n'
+            "    fi\n"
+            "}\n"
+            'PROMPT_COMMAND="_lask_prompt_cmd;${PROMPT_COMMAND}"'
+        )
+        print(init_code)
+
+
 def main() -> None:
     """
     Main entry point for the lask CLI tool.
@@ -462,6 +707,11 @@ def main() -> None:
     """
     # Load config from file
     config = LaskConfig.load()
+
+    # Handle --shell-init flag
+    if len(sys.argv) == 2 and sys.argv[1] == "--shell-init":
+        print_shell_init()
+        sys.exit(0)
 
     # Check if input is coming from a pipe
     if not sys.stdin.isatty():
@@ -489,8 +739,18 @@ def main() -> None:
         # Get the prompt from command line arguments
         prompt: str = " ".join(sys.argv[1:])
 
-        # Process the command line input as a one-off prompt
-        process_one_off_prompt(config, prompt)
+        # Determine whether to use smart command mode
+        smart = config.smart_command
+        if smart == "true":
+            process_smart_command(config, prompt)
+        elif smart == "auto":
+            if classify_prompt(config, prompt):
+                process_smart_command(config, prompt)
+            else:
+                process_one_off_prompt(config, prompt)
+        else:
+            # smart_command is false or unrecognised — normal prompt
+            process_one_off_prompt(config, prompt)
 
 
 def process_one_off_prompt(config: LaskConfig, prompt: str) -> None:

--- a/tests/test_chat_history.py
+++ b/tests/test_chat_history.py
@@ -1,0 +1,226 @@
+"""
+Tests for the ChatHistory class to ensure consistent chat history management.
+"""
+
+import sys
+from pathlib import Path
+
+# Add the project root to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.config import LaskConfig, ProviderConfig
+from src.chat_history import ChatHistory
+
+
+def _make_config(
+    provider: str = "openai",
+    default_system_prompt: str | None = None,
+    provider_system_prompt: str | None = None,
+    smart_context_commands: str = "true",
+    smart_context_output: str = "false",
+) -> LaskConfig:
+    """Helper to build a LaskConfig for testing."""
+    config = LaskConfig()
+    config.provider = provider
+    config.system_prompt = default_system_prompt
+    config.smart_context_commands = smart_context_commands
+    config.smart_context_output = smart_context_output
+    pc = ProviderConfig(system_prompt=provider_system_prompt)
+    config.providers[provider] = pc
+    return config
+
+
+class TestChatHistoryInit:
+    """Tests for ChatHistory initialization and system prompt handling."""
+
+    def test_no_system_prompt(self):
+        config = _make_config()
+        history = ChatHistory(config, "openai")
+        assert history.messages == []
+
+    def test_default_system_prompt(self):
+        config = _make_config(default_system_prompt="Be concise.")
+        history = ChatHistory(config, "openai")
+        assert len(history.messages) == 1
+        assert history.messages[0] == {"role": "system", "content": "Be concise."}
+
+    def test_provider_system_prompt_takes_precedence(self):
+        config = _make_config(
+            default_system_prompt="default prompt",
+            provider_system_prompt="provider prompt",
+        )
+        history = ChatHistory(config, "openai")
+        assert len(history.messages) == 1
+        assert history.messages[0]["content"] == "provider prompt"
+
+    def test_empty_command_history_on_init(self):
+        config = _make_config()
+        history = ChatHistory(config, "openai")
+        assert history.command_history == []
+
+
+class TestChatHistoryMessages:
+    """Tests for adding messages to the conversation."""
+
+    def test_add_user_message(self):
+        config = _make_config()
+        history = ChatHistory(config, "openai")
+        history.add_user_message("Hello")
+        assert history.messages == [{"role": "user", "content": "Hello"}]
+
+    def test_add_assistant_message(self):
+        config = _make_config()
+        history = ChatHistory(config, "openai")
+        history.add_assistant_message("Hi there")
+        assert history.messages == [{"role": "assistant", "content": "Hi there"}]
+
+    def test_multi_turn_conversation(self):
+        config = _make_config(default_system_prompt="System")
+        history = ChatHistory(config, "openai")
+        history.add_user_message("Q1")
+        history.add_assistant_message("A1")
+        history.add_user_message("Q2")
+        history.add_assistant_message("A2")
+
+        assert len(history.messages) == 5
+        assert history.messages[0]["role"] == "system"
+        assert history.messages[1] == {"role": "user", "content": "Q1"}
+        assert history.messages[2] == {"role": "assistant", "content": "A1"}
+        assert history.messages[3] == {"role": "user", "content": "Q2"}
+        assert history.messages[4] == {"role": "assistant", "content": "A2"}
+
+
+class TestChatHistorySmartCommands:
+    """Tests for smart command history management."""
+
+    def test_add_command_entry(self):
+        config = _make_config()
+        history = ChatHistory(config, "openai")
+        entry = {"prompt": "list files", "command": "ls", "output": "file.txt"}
+        history.add_command_entry(entry)
+
+        assert len(history.command_history) == 1
+        assert history.command_history[0] == entry
+
+    def test_add_smart_command_context_with_all_enabled(self):
+        config = _make_config(
+            smart_context_commands="true",
+            smart_context_output="true",
+        )
+        history = ChatHistory(config, "openai")
+        entry = {
+            "prompt": "list files",
+            "command": "ls -la",
+            "output": "total 8\nfile.txt",
+        }
+        history.add_smart_command_context(entry)
+
+        assert len(history.messages) == 1
+        msg = history.messages[0]
+        assert msg["role"] == "assistant"
+        assert "[Ran command: ls -la]" in msg["content"]
+        assert "[Output:" in msg["content"]
+        assert "file.txt" in msg["content"]
+
+    def test_add_smart_command_context_commands_disabled(self):
+        config = _make_config(
+            smart_context_commands="false",
+            smart_context_output="true",
+        )
+        history = ChatHistory(config, "openai")
+        entry = {"prompt": "list files", "command": "ls", "output": "file.txt"}
+        history.add_smart_command_context(entry)
+
+        msg = history.messages[0]
+        assert "command context is disabled" in msg["content"]
+        assert "[Output:" in msg["content"]
+
+    def test_add_smart_command_context_output_disabled(self):
+        config = _make_config(
+            smart_context_commands="true",
+            smart_context_output="false",
+        )
+        history = ChatHistory(config, "openai")
+        entry = {"prompt": "list files", "command": "ls", "output": "file.txt"}
+        history.add_smart_command_context(entry)
+
+        msg = history.messages[0]
+        assert "[Ran command: ls]" in msg["content"]
+        assert "output context is disabled" in msg["content"]
+
+    def test_add_smart_command_context_no_output(self):
+        config = _make_config(
+            smart_context_commands="true",
+            smart_context_output="true",
+        )
+        history = ChatHistory(config, "openai")
+        entry = {"prompt": "list files", "command": "ls"}
+        history.add_smart_command_context(entry)
+
+        msg = history.messages[0]
+        assert "[Ran command: ls]" in msg["content"]
+        # No output in entry → output context disabled message
+        assert "output context is disabled" in msg["content"]
+
+    def test_command_entry_and_context_together(self):
+        """Smart command adds both to command_history and to messages."""
+        config = _make_config(
+            smart_context_commands="true",
+            smart_context_output="true",
+        )
+        history = ChatHistory(config, "openai")
+        entry = {"prompt": "list files", "command": "ls", "output": "a.py"}
+        history.add_command_entry(entry)
+        history.add_smart_command_context(entry)
+
+        assert len(history.command_history) == 1
+        assert len(history.messages) == 1
+        assert history.messages[0]["role"] == "assistant"
+
+
+class TestChatHistoryConsistency:
+    """Ensure the same ChatHistory works for both REPL-like and one-off-like usage."""
+
+    def test_one_off_pattern(self):
+        """Simulates the one-off prompt pattern: system prompt + single user message."""
+        config = _make_config(default_system_prompt="Be helpful.")
+        history = ChatHistory(config, "openai")
+        history.add_user_message("What is Python?")
+
+        assert len(history.messages) == 2
+        assert history.messages[0]["role"] == "system"
+        assert history.messages[1]["role"] == "user"
+
+    def test_repl_pattern(self):
+        """Simulates the REPL pattern: system prompt + multi-turn + smart commands."""
+        config = _make_config(
+            default_system_prompt="System",
+            smart_context_commands="true",
+            smart_context_output="true",
+        )
+        history = ChatHistory(config, "openai")
+
+        # First turn: normal prompt
+        history.add_user_message("Hello")
+        history.add_assistant_message("Hi!")
+
+        # Second turn: smart command
+        entry = {"prompt": "list files", "command": "ls", "output": "a.py"}
+        history.add_command_entry(entry)
+        history.add_smart_command_context(entry)
+
+        # Third turn: normal prompt referencing the command
+        history.add_user_message("What does a.py do?")
+        history.add_assistant_message("It does things.")
+
+        assert len(history.messages) == 6
+        roles = [m["role"] for m in history.messages]
+        assert roles == [
+            "system",
+            "user",
+            "assistant",
+            "assistant",
+            "user",
+            "assistant",
+        ]
+        assert len(history.command_history) == 1


### PR DESCRIPTION
Adds support for smart commands, where the prompt is classified first (if enabled), and then is handled by the appropriate prompt.

The command is then presented to the user, and the user can press "Enter" to accept, and run, the command. Or cancel by pressing anything other than enter. Eg.:

```bash
$ lask show diff between current branch and main

  git diff HEAD..main

Press Enter to run, or any other key to abort.
```
